### PR TITLE
fixes for

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,8 +84,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 			# This _should_ happen automatically. We're explicitly syncing
 			# the a folder between the host and guest environments.
 			# Useful because it makes sharing the Makefile and config stuff
-			# seamless.
-			server.vm.synced_folder "nomad", "/home/vagrant/nomad"
+			# seamless. updated the local sync folder
+			server.vm.synced_folder "../nomad-vagrant-cluster", "/home/vagrant/nomad"
 			
 			# Hacky. We're using using an envar to represent
 			# the "public" ip we're assigning to each VM.

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -9,8 +9,8 @@
   box: bento/ubuntu-18.04
   ram: 512
   ip: 172.17.8.102
-# - name: nomad-client-two
-#   hostname: client-two
-#   box: bento/ubuntu-18.04
-#   ram: 512
-#   ip: 172.17.8.103
+- name: nomad-client-two
+  hostname: client-two
+  box: bento/ubuntu-18.04
+  ram: 512
+  ip: 172.17.8.103


### PR DESCRIPTION
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* The host path of the shared folder is missing: nomad

Also only one node comes up, so enabled the second client as well